### PR TITLE
accept strings for max_id

### DIFF
--- a/lib/RestParameterValidator.js
+++ b/lib/RestParameterValidator.js
@@ -127,8 +127,8 @@ RestParameterValidator.prototype.validateHideThread = function(parameters)
 
 RestParameterValidator.prototype.validateMaxId = function(parameters)
 {
-    var maxId = parameters['max_id'];
-    if (maxId !== undefined && typeof maxId !== 'number')
+    var maxId = parameters['max_id'], type = typeof maxId;
+    if (maxId !== undefined && (type !== 'number' && type !== 'string'))
     {
         throw new Error('Expected number.');
     }


### PR DESCRIPTION
twitter ids are long beyond the maxint, so they are usually represented as strings in node.